### PR TITLE
Fix revoke leases func

### DIFF
--- a/path_credentials.go
+++ b/path_credentials.go
@@ -53,9 +53,9 @@ func (b *Backend) pathCredentialsRead(ctx context.Context, req *logical.Request,
 
 type walEntry struct {
 	UserName             string
-	ProjectID            string
-	OrganizationID       string
-	ProgrammaticAPIKeyID string
+	ProjectID            string `mapstructure:"project_id"`
+	OrganizationID       string `mapstructure:"organization_id"`
+	ProgrammaticAPIKeyID string `mapstructure:"programmatic_api_key_id"`
 }
 
 func genUsername(displayName string) (string, error) {

--- a/secret_programmatic_api_keys.go
+++ b/secret_programmatic_api_keys.go
@@ -245,6 +245,7 @@ func (b *Backend) pathProgrammaticAPIKeyRollback(ctx context.Context, req *logic
 			}
 			return err
 		}
+		return nil
 	}
 
 	if isProjectKey(entry.OrganizationID, entry.ProjectID) {
@@ -256,6 +257,7 @@ func (b *Backend) pathProgrammaticAPIKeyRollback(ctx context.Context, req *logic
 			}
 			return err
 		}
+		return nil
 	}
 
 	return fmt.Errorf("Programmatic API key %s type not found, not deleting", entry.ProgrammaticAPIKeyID)


### PR DESCRIPTION
- Remove switch to delete duplicate code
- Add tags so mapstructure can decode the walEntry
- Return an error if the type of the cred cannot be found