### PR TITLE
Fix ip whitelist not added on project keys

### DIFF
--- a/secret_programmatic_api_keys.go
+++ b/secret_programmatic_api_keys.go
@@ -290,7 +290,23 @@ func (b *Backend) pathProgrammaticAPIKeyRollback(ctx context.Context, req *logic
 
 		}
 
-		orgID := foundKey.Roles[0].OrgID
+		if len(foundKey.Roles) == 0 {
+			return fmt.Errorf("missing roles on programmatic key %s", foundKey.ID)
+		}
+
+		// find the first orgID
+		orgID := ""
+		for _, r := range foundKey.Roles {
+			if len(r.OrgID) > 0 {
+				orgID = r.OrgID
+				break
+			}
+		}
+
+		// if orgID it's not found, return an error
+		if len(orgID) == 0 {
+			return fmt.Errorf("missing orgID on programmatic key %s", foundKey.ID)
+		}
 
 		// now, delete the user
 		res, err := client.ProjectAPIKeys.Unassign(ctx, entry.ProjectID, entry.ProgrammaticAPIKeyID)

--- a/secret_programmatic_api_keys.go
+++ b/secret_programmatic_api_keys.go
@@ -287,7 +287,6 @@ func (b *Backend) pathProgrammaticAPIKeyRollback(ctx context.Context, req *logic
 				foundKey = key
 				break
 			}
-
 		}
 
 		if len(foundKey.Roles) == 0 {

--- a/test_env.go
+++ b/test_env.go
@@ -79,6 +79,7 @@ func (e *testEnv) AddProgrammaticAPIKeyRole(t *testing.T) {
 func (e *testEnv) AddProgrammaticAPIKeyRoleWithProjectIDAndOrgID(t *testing.T) {
 	roles := []string{"ORG_MEMBER"}
 	projectRoles := []string{"GROUP_READ_ONLY"}
+	ips := []string{"192.168.1.1", "192.168.1.2"}
 	req := &logical.Request{
 		Operation: logical.UpdateOperation,
 		Path:      "roles/test-programmatic-key",
@@ -88,6 +89,7 @@ func (e *testEnv) AddProgrammaticAPIKeyRoleWithProjectIDAndOrgID(t *testing.T) {
 			"project_id":      e.ProjectID,
 			"roles":           roles,
 			"project_roles":   projectRoles,
+			"ip_addresses":    ips,
 		},
 	}
 	resp, err := e.Backend.HandleRequest(e.Context, req)


### PR DESCRIPTION
# Overview
- Added the code to add IP and CIDR whitelist to Project API Keys
- Fixed a case where the Project API keys are not deleted

# Design of Change
Testing from customer

# Related Issues/Pull Requests
No related issues on github

# Contributor Checklist
Changes to functionality (not to UI)


PASS
ok  	github.com/hashicorp/vault-plugin-secrets-mongodbatlas	6.478s
[x] Backwards compatible
