### PR TITLE
[Internal only change] Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.12
     working_directory: /go/src/github.com/hashicorp/vault-plugin-secrets-mongodbatlas
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ bin: fmtcheck generate
 
 default: dev
 
+dockerbuild: fmtcheck
+	@CGO_ENABLED=0 BUILD_TAGS='$(BUILD_TAGS)' DOCKER_BUILD=1 sh -c "'$(CURDIR)/scripts/build.sh'"
+
 # dev creates binaries for testing Vault locally. These are put
 # into ./bin/ as well as $GOPATH/bin.
 dev: fmtcheck generate

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -16,7 +16,7 @@ docker run --rm -d -p8200:8200 --name vaultplg -v "$(pwd)/$tmpdir/data":/data -v
   "disable_mlock": true,
   "api_addr": "http://localhost:8200"
 }
-' vault server
+' docker.mirror.hashicorp.services/vault server
 sleep 1
 
 export VAULT_ADDR=http://localhost:8200

--- a/docker-test.sh
+++ b/docker-test.sh
@@ -7,7 +7,8 @@ make dockerbuild
 docker kill vaultplg 2>/dev/null || true
 tmpdir=$(mktemp -d vaultplgXXXXXX)
 mkdir "$tmpdir/data"
-docker run --rm -d -p8200:8200 --name vaultplg -v "$(pwd)/$tmpdir/data":/data -v $(pwd)/bin:/example --cap-add=IPC_LOCK -e 'VAULT_LOCAL_CONFIG=
+PLUGIN_DIR="$(pwd)/pkg/linux_amd64"
+docker run --rm -d -p8200:8200 --name vaultplg -v "$(pwd)/$tmpdir/data":/data -v "${PLUGIN_DIR}":/example --cap-add=IPC_LOCK -e 'VAULT_LOCAL_CONFIG=
 {
   "backend": {"file": {"path": "/data"}},
   "listener": [{"tcp": {"address": "0.0.0.0:8200", "tls_disable": true}}],
@@ -27,15 +28,9 @@ vault operator unseal $(echo "$initoutput" | jq -r .unseal_keys_hex[0])
 export VAULT_TOKEN=$(echo "$initoutput" | jq -r .root_token)
 
 vault write sys/plugins/catalog/secret/vault-plugin-secrets-mongodbatlas \
-    sha_256=$(shasum -a 256 bin/vault-plugin-secrets-mongodbatlas | cut -d' ' -f1) \
+    sha_256=$(shasum -a 256 "${PLUGIN_DIR}/vault-plugin-secrets-mongodbatlas" | cut -d' ' -f1) \
     command="vault-plugin-secrets-mongodbatlas"
 
 vault secrets enable \
     -path="mongodbatlas" \
     -plugin-name="vault-plugin-secrets-mongodbatlas" plugin
-
-vault write sys/plugins/catalog/database/mongodbatlas-database-plugin \
-    sha256=$(shasum -a 256 bin/mongodbatlas-database-plugin | cut -d' ' -f1) \
-    command="mongodbatlas-database-plugin"
-
-vault secrets enable database

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,7 @@ GIT_DIRTY="$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)"
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd netbsd solaris}
-XC_OSARCH=${XC_OSARCH:-"linux/386 linux/amd64 linux/arm linux/arm64 darwin/386 darwin/amd64 windows/386 windows/amd64 freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 openbsd/arm netbsd/386 netbsd/amd64 netbsd/arm solaris/amd64"}
+XC_OSARCH=${XC_OSARCH:-"linux/386 linux/amd64 linux/arm linux/arm64 darwin/amd64 windows/386 windows/amd64 freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 openbsd/arm netbsd/386 netbsd/amd64 netbsd/arm solaris/amd64"}
 
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in


### PR DESCRIPTION
# Overview

Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 
