### PR TITLE
Update MongoDB Atlas client library

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -77,7 +77,7 @@ func TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew(t *testing.T) {
 
 }
 
-func TestAcceptanceProgrammaticAPIKey_ProjectWithIPWhitelist(t *testing.T) {
+func TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist(t *testing.T) {
 	if !runAcceptanceTests {
 		t.SkipNow()
 	}
@@ -95,7 +95,7 @@ func TestAcceptanceProgrammaticAPIKey_ProjectWithIPWhitelist(t *testing.T) {
 
 }
 
-func TestAcceptanceProgrammaticAPIKey_WithIPWhitelist(t *testing.T) {
+func TestAcceptanceProgrammaticAPIKey_WithIPAccesslist(t *testing.T) {
 	if !runAcceptanceTests {
 		t.SkipNow()
 	}
@@ -113,7 +113,7 @@ func TestAcceptanceProgrammaticAPIKey_WithIPWhitelist(t *testing.T) {
 
 }
 
-func TestAcceptanceProgrammaticAPIKey_WithCIDRWhitelist(t *testing.T) {
+func TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist(t *testing.T) {
 	if !runAcceptanceTests {
 		t.SkipNow()
 	}
@@ -131,7 +131,7 @@ func TestAcceptanceProgrammaticAPIKey_WithCIDRWhitelist(t *testing.T) {
 
 }
 
-func TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPWhitelist(t *testing.T) {
+func TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist(t *testing.T) {
 	if !runAcceptanceTests {
 		t.SkipNow()
 	}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200305172021-03a3749f220d
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pierrec/lz4 v2.2.6+incompatible // indirect
-	go.mongodb.org/atlas v0.5.0
+	go.mongodb.org/atlas v0.7.1
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-go.mongodb.org/atlas v0.5.0 h1:WoeXdXSLCyquhSqSqTa0PwpjxWZbm70E1Gkbx+w3Sco=
-go.mongodb.org/atlas v0.5.0/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
+go.mongodb.org/atlas v0.7.1 h1:hNBtwtKgmhB9vmSX/JyN/cArmhzyy4ihKpmXSMIc4mw=
+go.mongodb.org/atlas v0.7.1/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480 h1:O5YqonU5IWby+w98jVUG9h7zlCWCcH4RHyPVReBmhzk=

--- a/path_roles.go
+++ b/path_roles.go
@@ -33,11 +33,11 @@ func (b *Backend) pathRoles() *framework.Path {
 			},
 			"ip_addresses": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: fmt.Sprintf("IP address to be added to the whitelist for the API key. Optional for %s and %s keys.", orgProgrammaticAPIKey, projectProgrammaticAPIKey),
+				Description: fmt.Sprintf("IP address to be added to the access list for the API key. Optional for %s and %s keys.", orgProgrammaticAPIKey, projectProgrammaticAPIKey),
 			},
 			"cidr_blocks": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: fmt.Sprintf("Whitelist entry in CIDR notation to be added for the API key. Optional for %s and %s keys.", orgProgrammaticAPIKey, projectProgrammaticAPIKey),
+				Description: fmt.Sprintf("Access list entry in CIDR notation to be added for the API key. Optional for %s and %s keys.", orgProgrammaticAPIKey, projectProgrammaticAPIKey),
 			},
 			"project_roles": {
 				Type:        framework.TypeCommaStringSlice,
@@ -105,7 +105,7 @@ func (b *Backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 		credentialEntry.OrganizationID = organizationIDRaw.(string)
 	}
 
-	getAPIWhitelistArgs(credentialEntry, d)
+	getAPIAccessListArgs(credentialEntry, d)
 
 	if projectIDRaw, ok := d.GetOk("project_id"); ok {
 		projectID := projectIDRaw.(string)
@@ -149,7 +149,7 @@ func (b *Backend) pathRolesWrite(ctx context.Context, req *logical.Request, d *f
 	return &resp, nil
 }
 
-func getAPIWhitelistArgs(credentialEntry *atlasCredentialEntry, d *framework.FieldData) {
+func getAPIAccessListArgs(credentialEntry *atlasCredentialEntry, d *framework.FieldData) {
 
 	if cidrBlocks, ok := d.GetOk("cidr_blocks"); ok {
 		credentialEntry.CIDRBlocks = cidrBlocks.([]string)
@@ -247,7 +247,7 @@ The "roles" parameter specifies the MongoDB Atlas Programmatic Key roles that sh
 to the Programmatic API keys created for a given role. At least one role should be provided
 and must be valid for key level (project or org).
 
-"ip_addresses" and "cidr_blocks" are used to add whitelist entries for the API key.
+"ip_addresses" and "cidr_blocks" are used to add access list entries for the API key.
 
 "project_roles" is used when both "organization_id" and "project_id" are supplied. 
 And it's a list of roles that the API Key should be granted. A minimum of one role 

--- a/secret_programmatic_api_keys.go
+++ b/secret_programmatic_api_keys.go
@@ -115,7 +115,7 @@ func createOrgKey(ctx context.Context, client *mongodbatlas.Client, apiKeyDescri
 		return nil, err
 	}
 
-	if err := addWhitelistEntry(ctx, client, credentialEntry.OrganizationID, key.ID, credentialEntry); err != nil {
+	if err := addAccessListEntry(ctx, client, credentialEntry.OrganizationID, key.ID, credentialEntry); err != nil {
 		return nil, err
 	}
 
@@ -143,13 +143,13 @@ func createProjectAPIKey(ctx context.Context, client *mongodbatlas.Client, apiKe
 		}
 	}
 
-	// if we have whitelist entries and no orgIds then return an error
+	// if we have access list entries and no orgIds then return an error
 	if (len(credentialEntry.IPAddresses)+len(credentialEntry.CIDRBlocks)) > 0 && len(orgIDs) == 0 {
 		return nil, fmt.Errorf("No organization ID was found on programmatic key roles")
 	}
 
 	for orgID := range orgIDs {
-		if err := addWhitelistEntry(ctx, client, orgID, key.ID, credentialEntry); err != nil {
+		if err := addAccessListEntry(ctx, client, orgID, key.ID, credentialEntry); err != nil {
 			return nil, err
 		}
 	}
@@ -172,17 +172,17 @@ func createAndAssignKey(ctx context.Context, client *mongodbatlas.Client, apiKey
 	return key, nil
 }
 
-func addWhitelistEntry(ctx context.Context, client *mongodbatlas.Client, orgID string, keyID string, cred *atlasCredentialEntry) error {
-	var entries []*mongodbatlas.WhitelistAPIKeysReq
+func addAccessListEntry(ctx context.Context, client *mongodbatlas.Client, orgID string, keyID string, cred *atlasCredentialEntry) error {
+	var entries []*mongodbatlas.AccessListAPIKeysReq
 	for _, cidrBlock := range cred.CIDRBlocks {
-		cidr := &mongodbatlas.WhitelistAPIKeysReq{
+		cidr := &mongodbatlas.AccessListAPIKeysReq{
 			CidrBlock: cidrBlock,
 		}
 		entries = append(entries, cidr)
 	}
 
 	for _, ipAddress := range cred.IPAddresses {
-		ip := &mongodbatlas.WhitelistAPIKeysReq{
+		ip := &mongodbatlas.AccessListAPIKeysReq{
 			IPAddress: ipAddress,
 		}
 		entries = append(entries, ip)
@@ -190,7 +190,7 @@ func addWhitelistEntry(ctx context.Context, client *mongodbatlas.Client, orgID s
 	}
 
 	if entries != nil {
-		_, _, err := client.WhitelistAPIKeys.Create(ctx, orgID, keyID, entries)
+		_, _, err := client.AccessListAPIKeys.Create(ctx, orgID, keyID, entries)
 		return err
 
 	}

--- a/website/source/docs/secrets/atlasmongodb/index.html.md
+++ b/website/source/docs/secrets/atlasmongodb/index.html.md
@@ -47,7 +47,7 @@ steps are usually completed by an operator or configuration management tool.
     of a public and private key so ensure you have both. Regarding roles, the Organization Owner and
     Project Owner roles should be sufficient for most needs, however be sure to check what each roles
     grants in the [MongoDB Atlas Programmatic API Key User Roles documentation](https://docs.atlas.mongodb.com/reference/user-roles/).
-    Also ensure you set an IP Whitelist when creating the key.
+    Also ensure you set an IP Access List when creating the key.
 
     For more detailed instructions on how to create a Programmatic API Key in the Atlas UI, including
     available roles, visit the [Programmatic API Key documenation](https://docs.atlas.mongodb.com/configure-api-access/#programmatic-api-keys).
@@ -81,8 +81,8 @@ either the MongoDB Atlas Organization or Project level with the designated role(
   - Must be granted appropriate roles to complete required tasks
   - Must belong to one organization, but may be granted access to any number of
     projects in that organization.
-  - May have an IP whitelist configured and some capabilities may require a
-    whitelist to be configured (these are noted in the MongoDB Atlas API
+  - May have an IP access list configured and some capabilities may require an
+    access list to be configured (these are noted in the MongoDB Atlas API
     documentation).
 
 
@@ -112,12 +112,12 @@ $ vault write mongodbatlas/roles/test \
 ```
 
 In both of these examples, after performing a read on `mongodbatlas/creds/test`, for an example of a `read` action
-refer to [## Programmatic API Key Whitelist](#programmatic-api-key-whitelist) section.
+refer to [## Programmatic API Key Access List](#programmatic-api-key-access-list) section.
 
-## Programmatic API Key Whitelist
+## Programmatic API Key Access List
 
-Programmatic API Key access can and should be limited with a IP Whitelist. In the following example both a CIDR
-block and IP address are added to the IP whitelist for Keys generated with this Vault role:
+Programmatic API Key access can and should be limited with an IP access list. In the following example both a CIDR
+block and IP address are added to the IP access list for Keys generated with this Vault role:
 
 ```bash
   $ vault write atlas/roles/test \


### PR DESCRIPTION
# Overview
Update from whitelist to equivalent allow list API endpoints, whitelist will be deprecated June this year.

Acceptance test output:

```bash
go test -v ./...
=== RUN   TestAcceptanceProgrammaticAPIKey
=== RUN   TestAcceptanceProgrammaticAPIKey/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey/add_programmatic_API_Key_role
=== RUN   TestAcceptanceProgrammaticAPIKey/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey/renew_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey (0.92s)
    --- PASS: TestAcceptanceProgrammaticAPIKey/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey/add_programmatic_API_Key_role (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey/read_programmatic_API_key_cred (0.53s)
    --- PASS: TestAcceptanceProgrammaticAPIKey/renew_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey/revoke_programmatic_API_key_creds (0.39s)
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectID
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectID/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectID/add_programmatic_API_Key_role
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectID/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectID/renew_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectID/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectID (0.87s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectID/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectID/add_programmatic_API_Key_role (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectID/read_programmatic_API_key_cred (0.28s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectID/renew_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectID/revoke_programmatic_API_key_creds (0.59s)
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/add_programmatic_API_Key_role
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/check_lease_for_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/extend_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/check_lease_for_programmatic_API_key_cred#01
=== RUN   TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew (0.80s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/add_programmatic_API_Key_role (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/read_programmatic_API_key_cred (0.21s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/check_lease_for_programmatic_API_key_cred (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/extend_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/check_lease_for_programmatic_API_key_cred#01 (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithProjectIDRenew/revoke_programmatic_API_key_creds (0.59s)
=== RUN   TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist
=== RUN   TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/add_programmatic_API_Key_role
=== RUN   TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/renew_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist (1.25s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/add_programmatic_API_Key_role (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/read_programmatic_API_key_cred (0.42s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/renew_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_ProjectWithIPAccesslist/revoke_programmatic_API_key_creds (0.84s)
=== RUN   TestAcceptanceProgrammaticAPIKey_WithIPAccesslist
=== RUN   TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/add_programmatic_API_Key_role
=== RUN   TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/renew_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey_WithIPAccesslist (0.84s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/add_programmatic_API_Key_role (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/read_programmatic_API_key_cred (0.41s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/renew_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithIPAccesslist/revoke_programmatic_API_key_creds (0.43s)
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/add_programmatic_API_Key_role
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/renew_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist (0.97s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/add_programmatic_API_Key_role (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/read_programmatic_API_key_cred (0.41s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/renew_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAccesslist/revoke_programmatic_API_key_creds (0.56s)
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/add_programmatic_API_Key_role
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/renew_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist (0.83s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/add_programmatic_API_Key_role (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/read_programmatic_API_key_cred (0.44s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/renew_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithCIDRAndIPAccesslist/revoke_programmatic_API_key_creds (0.38s)
=== RUN   TestAcceptanceProgrammaticAPIKey_AssignToProject
=== RUN   TestAcceptanceProgrammaticAPIKey_AssignToProject/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey_AssignToProject/add_programmatic_API_Key_role
=== RUN   TestAcceptanceProgrammaticAPIKey_AssignToProject/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_AssignToProject/renew_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey_AssignToProject/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey_AssignToProject (1.32s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_AssignToProject/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_AssignToProject/add_programmatic_API_Key_role (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_AssignToProject/read_programmatic_API_key_cred (0.69s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_AssignToProject/renew_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_AssignToProject/revoke_programmatic_API_key_creds (0.62s)
=== RUN   TestAcceptanceProgrammaticAPIKey_WithTTL
=== RUN   TestAcceptanceProgrammaticAPIKey_WithTTL/add_config
=== RUN   TestAcceptanceProgrammaticAPIKey_WithTTL/add_programmatic_API_Key_role_with_TTL
=== RUN   TestAcceptanceProgrammaticAPIKey_WithTTL/read_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_WithTTL/check_lease_for_programmatic_API_key_cred
=== RUN   TestAcceptanceProgrammaticAPIKey_WithTTL/renew_programmatic_API_key_creds
=== RUN   TestAcceptanceProgrammaticAPIKey_WithTTL/revoke_programmatic_API_key_creds
--- PASS: TestAcceptanceProgrammaticAPIKey_WithTTL (0.59s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithTTL/add_config (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithTTL/add_programmatic_API_Key_role_with_TTL (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithTTL/read_programmatic_API_key_cred (0.20s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithTTL/check_lease_for_programmatic_API_key_cred (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithTTL/renew_programmatic_API_key_creds (0.00s)
    --- PASS: TestAcceptanceProgrammaticAPIKey_WithTTL/revoke_programmatic_API_key_creds (0.38s)
=== RUN   TestBackend_PathConfig
--- PASS: TestBackend_PathConfig (0.00s)
=== RUN   TestBackend_PathListCredentials
--- PASS: TestBackend_PathListCredentials (0.00s)
PASS
ok      github.com/hashicorp/vault-plugin-secrets-mongodbatlas  8.721s
?       github.com/hashicorp/vault-plugin-secrets-mongodbatlas/cmd/vault-plugin-secrets-mongodbatlas    [no test files]
```

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
