### PR TITLE
Upgrade go-client-mongodb-atlas version [VAULT-872]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/vault/sdk v0.1.14-0.20200305172021-03a3749f220d
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pierrec/lz4 v2.2.6+incompatible // indirect
-	go.mongodb.org/atlas v0.7.1
+	go.mongodb.org/atlas v0.7.2
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 go.mongodb.org/atlas v0.7.1 h1:hNBtwtKgmhB9vmSX/JyN/cArmhzyy4ihKpmXSMIc4mw=
 go.mongodb.org/atlas v0.7.1/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
+go.mongodb.org/atlas v0.7.2 h1:wB3+hP71t3mK+JOSrjBFbrzb5MsZRzDtZlpEKp58KK0=
+go.mongodb.org/atlas v0.7.2/go.mod h1:CIaBeO8GLHhtYLw7xSSXsw7N90Z4MFY87Oy9qcPyuEs=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480 h1:O5YqonU5IWby+w98jVUG9h7zlCWCcH4RHyPVReBmhzk=

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/accesslist_api_keys.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/accesslist_api_keys.go
@@ -1,0 +1,184 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const accessListAPIKeysPath = "orgs/%s/apiKeys/%s/accessList"
+
+// AccessListAPIKeysService is an interface for interfacing with the AccessList API Keys
+// endpoints of the MongoDB Atlas API.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/apiKeys#organization-api-key-access-list-endpoints
+type AccessListAPIKeysService interface {
+	List(context.Context, string, string, *ListOptions) (*AccessListAPIKeys, *Response, error)
+	Get(context.Context, string, string, string) (*AccessListAPIKey, *Response, error)
+	Create(context.Context, string, string, []*AccessListAPIKeysReq) (*AccessListAPIKeys, *Response, error)
+	Delete(context.Context, string, string, string) (*Response, error)
+}
+
+// AccessListAPIKeysServiceOp handles communication with the AccessList API keys related methods of the
+// MongoDB Atlas API
+type AccessListAPIKeysServiceOp service
+
+var _ AccessListAPIKeysService = &AccessListAPIKeysServiceOp{}
+
+// AccessListAPIKey represents a AccessList API key.
+type AccessListAPIKey struct {
+	CidrBlock       string  `json:"cidrBlock,omitempty"`       // CIDR-notated range of permitted IP addresses.
+	Count           int     `json:"count,omitempty"`           // Total number of requests that have originated from this IP address.
+	Created         string  `json:"created,omitempty"`         // Date this IP address was added to the access list.
+	IPAddress       string  `json:"ipAddress,omitempty"`       // IP address in the API access list.
+	LastUsed        string  `json:"lastUsed,omitempty"`        // Timestamp in ISO 8601 date and time format in UTC when the most recent request that originated from this IP address. This parameter only appears if at least one request has originated from this IP address, and is only updated when a permitted resource is accessed.
+	LastUsedAddress string  `json:"lastUsedAddress,omitempty"` // IP address from which the last call to the API was issued. This field only appears if at least one request has originated from this IP address.
+	Links           []*Link `json:"links,omitempty"`           // An array of documents, representing a link to one or more sub-resources and/or related resources such as list pagination. See Linking for more information.}
+}
+
+// AccessListAPIKeys represents all AccessList API keys.
+type AccessListAPIKeys struct {
+	Results    []*AccessListAPIKey `json:"results,omitempty"`    // Includes one AccessListAPIKey object for each item detailed in the results array section.
+	Links      []*Link             `json:"links,omitempty"`      // One or more links to sub-resources and/or related resources.
+	TotalCount int                 `json:"totalCount,omitempty"` // Count of the total number of items in the result set. It may be greater than the number of objects in the results array if the entire result set is paginated.
+}
+
+// AccessListAPIKeysReq represents the request to the mehtod create
+type AccessListAPIKeysReq struct {
+	IPAddress string `json:"ipAddress,omitempty"` // IP address to be added to the access list for the API key.
+	CidrBlock string `json:"cidrBlock,omitempty"` // CIDR-notation block of IP addresses to be added to the access list for the API key.
+}
+
+// List gets all AccessList API keys.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/api-access-list/get-all-api-access-entries/
+func (s *AccessListAPIKeysServiceOp) List(ctx context.Context, orgID, apiKeyID string, listOptions *ListOptions) (*AccessListAPIKeys, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+
+	path := fmt.Sprintf(accessListAPIKeysPath, orgID, apiKeyID)
+	path, err := setListOptions(path, listOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AccessListAPIKeys)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if l := root.Links; l != nil {
+		resp.Links = l
+	}
+
+	return root, resp, nil
+}
+
+// Get retrieve information on a single API Key access list entry using the unique identifier for the API Key and desired permitted address.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/api-access-list/get-one-api-access-entry/
+func (s *AccessListAPIKeysServiceOp) Get(ctx context.Context, orgID, apiKeyID, ipAddress string) (*AccessListAPIKey, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+	if ipAddress == "" {
+		return nil, nil, NewArgError("ipAddress", "must be set")
+	}
+
+	path := fmt.Sprintf(accessListAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AccessListAPIKey)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Create one or more new access list entries for the specified API Key.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/api-access-list/create-api-access-entries/
+func (s *AccessListAPIKeysServiceOp) Create(ctx context.Context, orgID, apiKeyID string, createRequest []*AccessListAPIKeysReq) (*AccessListAPIKeys, *Response, error) {
+	if orgID == "" {
+		return nil, nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, nil, NewArgError("apiKeyID", "must be set")
+	}
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(accessListAPIKeysPath, orgID, apiKeyID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AccessListAPIKeys)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Delete deletes the AccessList API keys.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/api-access-list/delete-one-api-access-entry/
+func (s *AccessListAPIKeysServiceOp) Delete(ctx context.Context, orgID, apiKeyID, ipAddress string) (*Response, error) {
+	if orgID == "" {
+		return nil, NewArgError("orgID", "must be set")
+	}
+	if apiKeyID == "" {
+		return nil, NewArgError("apiKeyID", "must be set")
+	}
+	if ipAddress == "" {
+		return nil, NewArgError("ipAddress", "must be set")
+	}
+
+	path := fmt.Sprintf(accessListAPIKeysPath+"/%s", orgID, apiKeyID, ipAddress)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.Client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/alert_configurations.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/alert_configurations.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -8,9 +22,9 @@ import (
 
 const alertConfigurationPath = "groups/%s/alertConfigs"
 
-// AlertConfigurationsService is an interface of the Alert Configuration
-// endpoints of the MongoDB Atlas API.
-// See more: hhttps://docs.atlas.mongodb.com/reference/api/alert-configurations
+// AlertConfigurationsService provides access to the alert configuration related functions in the Atlas API.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/alert-configurations
 type AlertConfigurationsService interface {
 	Create(context.Context, string, *AlertConfiguration) (*AlertConfiguration, *Response, error)
 	EnableAnAlertConfig(context.Context, string, string, *bool) (*AlertConfiguration, *Response, error)
@@ -69,7 +83,7 @@ type Matcher struct {
 type MetricThreshold struct {
 	MetricName string  `json:"metricName,omitempty"` // Name of the metric to check.
 	Operator   string  `json:"operator,omitempty"`   // Operator to apply when checking the current metric value against the threshold value.
-	Threshold  float64 `json:"threshold,omitempty"`  // Threshold value outside of which an alert will be triggered.
+	Threshold  float64 `json:"threshold"`            // Threshold value outside of which an alert will be triggered.
 	Units      string  `json:"units,omitempty"`      // The units for the threshold value.
 	Mode       string  `json:"mode,omitempty"`       // This must be set to AVERAGE. Atlas computes the current metric value as an average.
 }

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/alerts.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/alerts.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/api_keys.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/api_keys.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/atlas_users.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/atlas_users.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/auditing.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/auditing.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/aws_custom_dns.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/aws_custom_dns.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/checkpoints.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/checkpoints.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/cloud_provider_access.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/cloud_provider_access.go
@@ -1,0 +1,173 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+const cloudProviderAccessPath = "groups/%s/cloudProviderAccess"
+
+// CloudProviderAccessService provides access to the cloud provider access functions in the Atlas API.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-access/
+type CloudProviderAccessService interface {
+	ListRoles(context.Context, string) (*CloudProviderAccessRoles, *Response, error)
+	CreateRole(context.Context, string, *CloudProviderAccessRoleRequest) (*AWSIAMRole, *Response, error)
+	AuthorizeRole(context.Context, string, string, *CloudProviderAuthorizationRequest) (*AWSIAMRole, *Response, error)
+	DeauthorizeRole(context.Context, *CloudProviderDeauthorizationRequest) (*Response, error)
+}
+
+// ProjectIPAccessListServiceOp provides an implementation of the CloudProviderAccessService interface
+type CloudProviderAccessServiceOp service
+
+var _ CloudProviderAccessService = &CloudProviderAccessServiceOp{}
+
+// CloudProviderAccessRoles an array of awsIamRoles objects.
+type CloudProviderAccessRoles struct {
+	AWSIAMRoles []AWSIAMRole `json:"awsIamRoles,omitempty"` // Unique identifier of AWS security group in this access list entry.
+}
+
+// ProjectIPAccessLists is the response from the ProjectIPAccessListService.List.
+type AWSIAMRole struct {
+	AtlasAWSAccountARN         string          `json:"atlasAWSAccountArn,omitempty"`         // ARN associated with the Atlas AWS account used to assume IAM roles in your AWS account.
+	AtlasAssumedRoleExternalID string          `json:"atlasAssumedRoleExternalId,omitempty"` // Unique external ID Atlas uses when assuming the IAM role in your AWS account.
+	AuthorizedDate             string          `json:"authorizedDate,omitempty"`             //	Date on which this role was authorized.
+	CreatedDate                string          `json:"createdDate,omitempty"`                // Date on which this role was created.
+	FeatureUsages              []*FeatureUsage `json:"featureUsages,omitempty"`              // Atlas features this AWS IAM role is linked to.
+	IAMAssumedRoleARN          string          `json:"iamAssumedRoleArn,omitempty"`          // ARN of the IAM Role that Atlas assumes when accessing resources in your AWS account.
+	ProviderName               string          `json:"providerName,omitempty"`               // Name of the cloud provider. Currently limited to AWS.
+	RoleID                     string          `json:"roleId,omitempty"`                     // Unique ID of this role.
+}
+
+// FeatureUsage represents where the role sis being used
+type FeatureUsage struct {
+	FeatureType string      `json:"featureType,omitempty"`
+	FeatureID   interface{} `json:"featureId,omitempty"`
+}
+
+// CloudProviderAccessRoleRequest represent a new role creation
+type CloudProviderAccessRoleRequest struct {
+	ProviderName string `json:"providerName"`
+}
+
+// CloudProviderAuthorizationRequest represents an authorization request
+type CloudProviderAuthorizationRequest struct {
+	ProviderName      string `json:"providerName"`
+	IAMAssumedRoleARN string `json:"iamAssumedRoleArn"`
+}
+
+// CloudProviderAuthorizationRequest
+type CloudProviderDeauthorizationRequest struct {
+	ProviderName string
+	GroupID      string
+	RoleID       string
+}
+
+// ListRoles retrieve existing AWS IAM roles.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-get-roles/
+func (s *CloudProviderAccessServiceOp) ListRoles(ctx context.Context, groupID string) (*CloudProviderAccessRoles, *Response, error) {
+	path := fmt.Sprintf(cloudProviderAccessPath, groupID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(CloudProviderAccessRoles)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, nil
+}
+
+// Create creates an AWS IAM role.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-create-one-role/
+func (s *CloudProviderAccessServiceOp) CreateRole(ctx context.Context, groupID string, request *CloudProviderAccessRoleRequest) (*AWSIAMRole, *Response, error) {
+	if request == nil {
+		return nil, nil, NewArgError("request", "must be set")
+	}
+
+	path := fmt.Sprintf(cloudProviderAccessPath, groupID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AWSIAMRole)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// AuthorizeRole authorizes and configure an AWS Assumed IAM role.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-authorize-one-role/
+func (s *CloudProviderAccessServiceOp) AuthorizeRole(ctx context.Context, groupID, roleID string, request *CloudProviderAuthorizationRequest) (*AWSIAMRole, *Response, error) {
+	if roleID == "" {
+		return nil, nil, NewArgError("roleID", "must be set")
+	}
+
+	if request == nil {
+		return nil, nil, NewArgError("request", "must be set")
+	}
+
+	basePath := fmt.Sprintf(cloudProviderAccessPath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, roleID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPatch, path, request)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(AWSIAMRole)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// DeauthorizeRole deauthorizes an AWS Assumed IAM role.
+//
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-access-deauthorize-one-role/
+func (s *CloudProviderAccessServiceOp) DeauthorizeRole(ctx context.Context, request *CloudProviderDeauthorizationRequest) (*Response, error) {
+	if request.RoleID == "" {
+		return nil, NewArgError("roleID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(cloudProviderAccessPath, request.GroupID)
+	path := fmt.Sprintf("%s/%s/%s", basePath, request.ProviderName, request.RoleID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.Client.Do(ctx, req, nil)
+
+	return resp, err
+}

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/cloud_provider_snapshot_backup_policies.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/cloud_provider_snapshot_backup_policies.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/cloud_provider_snapshot_restore_jobs.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -12,7 +26,7 @@ const (
 
 // CloudProviderSnapshotRestoreJobsService is an interface for interfacing with the CloudProviderSnapshotRestoreJobs
 // endpoints of the MongoDB Atlas API.
-// See more: https://docs.atlas.mongodb.com/reference/api/cloudProviderSnapshotRestoreJobs/
+// See more: https://docs.atlas.mongodb.com/reference/api/cloud-provider-snapshot-restore-jobs/
 type CloudProviderSnapshotRestoreJobsService interface {
 	List(context.Context, *SnapshotReqPathParameters, *ListOptions) (*CloudProviderSnapshotRestoreJobs, *Response, error)
 	Get(context.Context, *SnapshotReqPathParameters) (*CloudProviderSnapshotRestoreJob, *Response, error)
@@ -28,22 +42,23 @@ var _ CloudProviderSnapshotRestoreJobsService = &CloudProviderSnapshotRestoreJob
 
 // CloudProviderSnapshotRestoreJob represents the structure of a cloudProviderSnapshotRestoreJob.
 type CloudProviderSnapshotRestoreJob struct {
-	ID                    string   `json:"id,omitempty"`                    // The unique identifier of the restore job.
-	SnapshotID            string   `json:"snapshotId,omitempty"`            // Unique identifier of the snapshot to restore.
-	DeliveryType          string   `json:"deliveryType,omitempty"`          // Type of restore job to create. Possible values are: automated or download or pointInTime
-	DeliveryURL           []string `json:"deliveryUrl,omitempty"`           // One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
-	TargetClusterName     string   `json:"targetClusterName,omitempty"`     // Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
-	TargetGroupID         string   `json:"targetGroupId,omitempty"`         // Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
-	Cancelled             bool     `json:"cancelled,omitempty"`             // Indicates whether the restore job was canceled.
-	CreatedAt             string   `json:"createdAt,omitempty"`             // UTC ISO 8601 formatted point in time when Atlas created the restore job.
-	Expired               bool     `json:"expired,omitempty"`               // Indicates whether the restore job expired.
-	ExpiresAt             string   `json:"expiresAt,omitempty"`             // UTC ISO 8601 formatted point in time when the restore job expires.
-	FinishedAt            string   `json:"finishedAt,omitempty"`            // UTC ISO 8601 formatted point in time when the restore job completed.
-	Links                 []*Link  `json:"links,omitempty"`                 // One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
-	Timestamp             string   `json:"timestamp,omitempty"`             // Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
-	OplogTs               int64    `json:"oplogTs,omitempty"`               //nolint:stylecheck // not changing this // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot. This is the first part of an Oplog timestamp.
-	OplogInc              int64    `json:"oplogInc,omitempty"`              // Oplog operation number from which to you want to restore this snapshot. This is the second part of an Oplog timestamp.
-	PointInTimeUTCSeconds int64    `json:"pointInTimeUTCSeconds,omitempty"` // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which you want to restore this snapshot.
+	ID                    string       `json:"id,omitempty"`                    // The unique identifier of the restore job.
+	SnapshotID            string       `json:"snapshotId,omitempty"`            // Unique identifier of the snapshot to restore.
+	Components            []*Component `json:"components,omitempty"`            // Collection of clusters to be downloaded. Atlas returns this parameter when restoring a sharded cluster and "deliveryType" : "download".
+	DeliveryType          string       `json:"deliveryType,omitempty"`          // Type of restore job to create. Possible values are: automated or download or pointInTime
+	DeliveryURL           []string     `json:"deliveryUrl,omitempty"`           // One or more URLs for the compressed snapshot files for manual download. Only visible if deliveryType is download.
+	TargetClusterName     string       `json:"targetClusterName,omitempty"`     // Name of the target Atlas cluster to which the restore job restores the snapshot. Only required if deliveryType is automated.
+	TargetGroupID         string       `json:"targetGroupId,omitempty"`         // Unique ID of the target Atlas project for the specified targetClusterName. Only required if deliveryType is automated.
+	Cancelled             bool         `json:"cancelled,omitempty"`             // Indicates whether the restore job was canceled.
+	CreatedAt             string       `json:"createdAt,omitempty"`             // UTC ISO 8601 formatted point in time when Atlas created the restore job.
+	Expired               bool         `json:"expired,omitempty"`               // Indicates whether the restore job expired.
+	ExpiresAt             string       `json:"expiresAt,omitempty"`             // UTC ISO 8601 formatted point in time when the restore job expires.
+	FinishedAt            string       `json:"finishedAt,omitempty"`            // UTC ISO 8601 formatted point in time when the restore job completed.
+	Links                 []*Link      `json:"links,omitempty"`                 // One or more links to sub-resources and/or related resources. The relations between URLs are explained in the Web Linking Specification.
+	Timestamp             string       `json:"timestamp,omitempty"`             // Timestamp in ISO 8601 date and time format in UTC when the snapshot associated to snapshotId was taken.
+	OplogTs               int64        `json:"oplogTs,omitempty"`               //nolint:stylecheck // not changing this // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which to you want to restore this snapshot. This is the first part of an Oplog timestamp.
+	OplogInc              int64        `json:"oplogInc,omitempty"`              // Oplog operation number from which to you want to restore this snapshot. This is the second part of an Oplog timestamp.
+	PointInTimeUTCSeconds int64        `json:"pointInTimeUTCSeconds,omitempty"` // Timestamp in the number of seconds that have elapsed since the UNIX epoch from which you want to restore this snapshot.
 }
 
 // CloudProviderSnapshotRestoreJobs represents an array of cloudProviderSnapshotRestoreJob
@@ -51,6 +66,11 @@ type CloudProviderSnapshotRestoreJobs struct {
 	Links      []*Link                            `json:"links"`
 	Results    []*CloudProviderSnapshotRestoreJob `json:"results"`
 	TotalCount int                                `json:"totalCount"`
+}
+
+type Component struct {
+	DownloadURL    string `json:"downloadUrl"`    // URL from which the snapshot of the components.replicaSetName should be downloaded. Atlas returns null for this parameter if the download URL has expired, has been used, or hasn't been created.
+	ReplicaSetName string `json:"replicaSetName"` // Name of the shard or config server included in the snapshot.
 }
 
 // List gets all cloud provider snapshot restore jobs for the specified cluster.

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/cloud_provider_snapshots.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/cloud_provider_snapshots.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/clusters.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/clusters.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -30,8 +44,9 @@ var _ ClustersService = &ClustersServiceOp{}
 
 // AutoScaling configures your cluster to automatically scale its storage
 type AutoScaling struct {
-	DiskGBEnabled *bool    `json:"diskGBEnabled,omitempty"`
-	Compute       *Compute `json:"compute,omitempty"`
+	AutoIndexingEnabled *bool    `json:"autoIndexingEnabled,omitempty"` // Autopilot mode is only available if you are enrolled in the Auto Pilot Early Access program.
+	Compute             *Compute `json:"compute,omitempty"`
+	DiskGBEnabled       *bool    `json:"diskGBEnabled,omitempty"`
 }
 
 // Compute Specifies whether the cluster automatically scales its cluster tier and whether the cluster can scale down.
@@ -77,12 +92,31 @@ type ReplicationSpec struct {
 	RegionsConfig map[string]RegionsConfig `json:"regionsConfig,omitempty"`
 }
 
+// PrivateEndpoint connection strings. Each object describes the connection strings
+// you can use to connect to this cluster through a private endpoint.
+// Atlas returns this parameter only if you deployed a private endpoint to all regions
+// to which you deployed this cluster's nodes.
+type PrivateEndpoint struct {
+	ConnectionString    string     `json:"connectionString,omitempty"`
+	Endpoints           []Endpoint `json:"endpoints,omitempty"`
+	SRVConnectionString string     `json:"srvConnectionString,omitempty"`
+	Type                string     `json:"type,omitempty"`
+}
+
+// Endpoint through which you connect to Atlas
+type Endpoint struct {
+	EndpointID   string `json:"endpointId,omitempty"`
+	ProviderName string `json:"providerName,omitempty"`
+	Region       string `json:"region,omitempty"`
+}
+
 // ConnectionStrings configuration for applications use to connect to this cluster
 type ConnectionStrings struct {
 	Standard          string            `json:"standard,omitempty"`
 	StandardSrv       string            `json:"standardSrv,omitempty"`
-	AwsPrivateLink    map[string]string `json:"awsPrivateLink,omitempty"`
-	AwsPrivateLinkSrv map[string]string `json:"awsPrivateLinkSrv,omitempty"`
+	PrivateEndpoint   []PrivateEndpoint `json:"privateEndpoint,omitempty"`
+	AwsPrivateLink    map[string]string `json:"awsPrivateLink,omitempty"`    // Deprecated: Use connectionStrings.PrivateEndpoint[n].ConnectionString
+	AwsPrivateLinkSrv map[string]string `json:"awsPrivateLinkSrv,omitempty"` // Deprecated: Use ConnectionStrings.privateEndpoint[n].SRVConnectionString
 	Private           string            `json:"private,omitempty"`
 	PrivateSrv        string            `json:"privateSrv,omitempty"`
 }
@@ -90,7 +124,7 @@ type ConnectionStrings struct {
 // Cluster represents MongoDB cluster.
 type Cluster struct {
 	AutoScaling              *AutoScaling             `json:"autoScaling,omitempty"`
-	BackupEnabled            *bool                    `json:"backupEnabled,omitempty"`
+	BackupEnabled            *bool                    `json:"backupEnabled,omitempty"` // Deprecated: Use ProviderBackupEnabled instead
 	BiConnector              *BiConnector             `json:"biConnector,omitempty"`
 	ClusterType              string                   `json:"clusterType,omitempty"`
 	DiskSizeGB               *float64                 `json:"diskSizeGB,omitempty"`

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/containers.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/containers.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/continuous_restore_jobs.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/continuous_restore_jobs.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/continuous_snaphots.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/continuous_snaphots.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/custom_db_roles.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/custom_db_roles.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/data_lakes.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/data_lakes.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -27,7 +41,10 @@ type DataLakeServiceOp service
 
 // AwsCloudProviderConfig is the data lake configuration for AWS
 type AwsCloudProviderConfig struct {
+	ExternalID        string `json:"externalId,omitempty"`
 	IAMAssumedRoleARN string `json:"iamAssumedRoleARN,omitempty"`
+	IAMUserARN        string `json:"iamUserARN,omitempty"`
+	RoleID            string `json:"roleId,omitempty"`
 	TestS3Bucket      string `json:"testS3Bucket,omitempty"`
 }
 
@@ -105,7 +122,8 @@ type DataLakeUpdateRequest struct {
 
 // DataLakeCreateRequest represents the required fields to create a new data lake
 type DataLakeCreateRequest struct {
-	Name string `json:"name,omitempty"`
+	Name                string               `json:"name,omitempty"`
+	CloudProviderConfig *CloudProviderConfig `json:"cloudProviderConfig,omitempty"`
 }
 
 // List gets all data lakes for the specified group.

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/database_users.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/database_users.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -53,7 +67,7 @@ type DatabaseUser struct {
 	AWSIAMType      string  `json:"awsIAMType,omitempty"`
 	GroupID         string  `json:"groupId,omitempty"`
 	Roles           []Role  `json:"roles,omitempty"`
-	Scopes          []Scope `json:"scopes,omitempty"`
+	Scopes          []Scope `json:"scopes"`
 	Password        string  `json:"password,omitempty"`
 	Username        string  `json:"username,omitempty"`
 }

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/default_mongodb_major_version.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/default_mongodb_major_version.go
@@ -1,0 +1,55 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+)
+
+const defaultMongoDBMajorVersionPath = "api/private/unauth/nds/defaultMongoDBMajorVersion"
+
+// DefaultMongoDBMajorVersionService this service is to be used by other MongoDB tools
+// to determine the current default major version of MongoDB Server in Atlas.
+//
+// We currently make no promise to support or document this service or endpoint
+// beyond what can be seen here.
+type DefaultMongoDBMajorVersionService interface {
+	Get(context.Context) (string, *Response, error)
+}
+
+// DefaultMongoDBMajorVersionServiceOp is an implementation of DefaultMongoDBMajorVersionService
+type DefaultMongoDBMajorVersionServiceOp struct {
+	Client PlainRequestDoer
+}
+
+var _ DefaultMongoDBMajorVersionService = &DefaultMongoDBMajorVersionServiceOp{}
+
+// Get gets the current major MongoDB version in Atlas
+func (s *DefaultMongoDBMajorVersionServiceOp) Get(ctx context.Context) (string, *Response, error) {
+	req, err := s.Client.NewPlainRequest(ctx, http.MethodGet, defaultMongoDBMajorVersionPath)
+	if err != nil {
+		return "", nil, err
+	}
+	root := new(bytes.Buffer)
+
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return "", resp, err
+	}
+
+	return root.String(), resp, err
+}

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/encryptions_at_rest.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/encryptions_at_rest.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -82,6 +96,8 @@ type AwsKms struct {
 	SecretAccessKey     string `json:"secretAccessKey,omitempty"`     // The IAM secret access key with permissions to access the customer master key specified by customerMasterKeyID.
 	CustomerMasterKeyID string `json:"customerMasterKeyID,omitempty"` // The AWS customer master key used to encrypt and decrypt the MongoDB master keys.
 	Region              string `json:"region,omitempty"`              // The AWS region in which the AWS customer master key exists: CA_CENTRAL_1, US_EAST_1, US_EAST_2, US_WEST_1, US_WEST_2, SA_EAST_1
+	RoleID              string `json:"roleId,omitempty"`              // ID of an AWS IAM role authorized to manage an AWS customer master key.
+	Valid               *bool  `json:"valid,omitempty"`               // Specifies whether the encryption key set for the provider is valid and may be used to encrypt and decrypt data.
 }
 
 // AzureKeyVault specifies Azure Key Vault configuration details and whether Encryption at Rest is enabled for an Atlas project.

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/errors.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/errors.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import "fmt"

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/events.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/events.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/global_clusters.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/global_clusters.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/indexes.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/indexes.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/ldap_configurations.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/ldap_configurations.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/link.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/link.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import "net/url"

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/logs.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/logs.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/maintenance.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/maintenance.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/mongodbatlas.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/mongodbatlas.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas // import "go.mongodb.org/atlas/mongodbatlas"
 
 import (
@@ -20,12 +34,15 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://cloud.mongodb.com/api/atlas/v1.0/"
-	jsonMediaType  = "application/json"
-	gzipMediaType  = "application/gzip"
-	libraryName    = "go-mongodbatlas"
-	// Version the version of the current API client
-	Version = "0.5.0" // Should be set to the next version planned to be released
+	CloudURL        = "https://cloud.mongodb.com/"
+	defaultBaseURL  = CloudURL + APIPublicV1Path
+	APIPublicV1Path = "api/atlas/v1.0/" // APIPublicV1Path specifies the v1 api path
+	jsonMediaType   = "application/json"
+	plainMediaType  = "text/plain"
+	gzipMediaType   = "application/gzip"
+	libraryName     = "go-mongodbatlas"
+	// Version the version of the current API client. Should be set to the next version planned to be released
+	Version = "0.7.2"
 )
 
 var (
@@ -56,6 +73,13 @@ type GZipRequestDoer interface {
 	NewGZipRequest(context.Context, string, string) (*http.Request, error)
 }
 
+// PlainRequestDoer minimum interface for any service of the client that should handle plain text
+type PlainRequestDoer interface {
+	Doer
+	Completer
+	NewPlainRequest(context.Context, string, string) (*http.Request, error)
+}
+
 // Client manages communication with MongoDBAtlas v1.0 API
 type Client struct {
 	client    *http.Client
@@ -78,6 +102,7 @@ type Client struct {
 	Containers                          ContainersService
 	EncryptionsAtRest                   EncryptionsAtRestService
 	WhitelistAPIKeys                    WhitelistAPIKeysService
+	AccessListAPIKeys                   AccessListAPIKeysService
 	PrivateIPMode                       PrivateIPModeService
 	MaintenanceWindows                  MaintenanceWindowsService
 	Teams                               TeamsService
@@ -86,6 +111,7 @@ type Client struct {
 	Auditing                            AuditingsService
 	AlertConfigurations                 AlertConfigurationsService
 	PrivateEndpoints                    PrivateEndpointsService
+	PrivateEndpointsDeprecated          PrivateEndpointsServiceDeprecated
 	X509AuthDBUsers                     X509AuthDBUsersService
 	ContinuousSnapshots                 ContinuousSnapshotsService
 	ContinuousRestoreJobs               ContinuousRestoreJobsService
@@ -108,6 +134,8 @@ type Client struct {
 	Integrations                        IntegrationsService
 	LDAPConfigurations                  LDAPConfigurationsService
 	PerformanceAdvisor                  PerformanceAdvisorService
+	CloudProviderAccess                 CloudProviderAccessService
+	DefaultMongoDBMajorVersion          DefaultMongoDBMajorVersionService
 
 	onRequestCompleted RequestCompletionCallback
 }
@@ -125,6 +153,9 @@ type Response struct {
 
 	// Links that were returned with the response.
 	Links []*Link `json:"links"`
+
+	// Raw data from server response
+	Raw []byte `json:"-"`
 }
 
 // ListOptions specifies the optional parameters to List methods that
@@ -141,8 +172,12 @@ type ListOptions struct {
 type ErrorResponse struct {
 	// HTTP response that caused this error
 	Response *http.Response
-	// The error code, which is simply the HTTP status code.
-	ErrorCode int `json:"Error"`
+
+	// The error code as specified in https://docs.atlas.mongodb.com/reference/api/api-errors/
+	ErrorCode string `json:"errorCode"`
+
+	// HTTP status code.
+	HTTPCode int `json:"error"`
 
 	// A short description of the error, which is simply the HTTP status phrase.
 	Reason string `json:"reason"`
@@ -218,6 +253,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.ProjectIPWhitelist = &ProjectIPWhitelistServiceOp{Client: c}
 	c.ProjectIPAccessList = &ProjectIPAccessListServiceOp{Client: c}
 	c.WhitelistAPIKeys = &WhitelistAPIKeysServiceOp{Client: c}
+	c.AccessListAPIKeys = &AccessListAPIKeysServiceOp{Client: c}
 	c.PrivateIPMode = &PrivateIPModeServiceOp{Client: c}
 	c.MaintenanceWindows = &MaintenanceWindowsServiceOp{Client: c}
 	c.Teams = &TeamsServiceOp{Client: c}
@@ -226,6 +262,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Auditing = &AuditingsServiceOp{Client: c}
 	c.AlertConfigurations = &AlertConfigurationsServiceOp{Client: c}
 	c.PrivateEndpoints = &PrivateEndpointsServiceOp{Client: c}
+	c.PrivateEndpointsDeprecated = &PrivateEndpointsServiceOpDeprecated{Client: c}
 	c.X509AuthDBUsers = &X509AuthDBUsersServiceOp{Client: c}
 	c.ContinuousRestoreJobs = &ContinuousRestoreJobsServiceOp{Client: c}
 	c.Checkpoints = &CheckpointsServiceOp{Client: c}
@@ -247,12 +284,26 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Integrations = &IntegrationsServiceOp{Client: c}
 	c.LDAPConfigurations = &LDAPConfigurationsServiceOp{Client: c}
 	c.PerformanceAdvisor = &PerformanceAdvisorServiceOp{Client: c}
+	c.CloudProviderAccess = &CloudProviderAccessServiceOp{Client: c}
+	c.DefaultMongoDBMajorVersion = &DefaultMongoDBMajorVersionServiceOp{Client: c}
 
 	return c
 }
 
-// ClientOpt are options for New.
+// ClientOpt configures a Client.
 type ClientOpt func(*Client) error
+
+// Options turns a list of ClientOpt instances into a ClientOpt.
+func Options(opts ...ClientOpt) ClientOpt {
+	return func(c *Client) error {
+		for _, opt := range opts {
+			if err := opt(c); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
 
 // New returns a new MongoDBAtlas API client instance.
 func New(httpClient *http.Client, opts ...ClientOpt) (*Client, error) {
@@ -329,9 +380,33 @@ func (c *Client) newEncodedBody(body interface{}) (io.Reader, error) {
 	return buf, err
 }
 
-// NewGZipRequest creates an API request that accepts gzip. A relative URL can be provided in urlStr, which will be resolved to the
+// NewGZipRequest creates an API request that accepts gzip.
+// A relative URL can be provided in urlStr, which will be resolved to the
 // BaseURL of the Client. Relative URLS should always be specified without a preceding slash.
 func (c *Client) NewGZipRequest(ctx context.Context, method, urlStr string) (*http.Request, error) {
+	req, err := c.newRequest(urlStr, method)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", gzipMediaType)
+
+	return req, nil
+}
+
+// NewPlainRequest creates an API request that accepts plain text.
+// A relative URL can be provided in urlStr, which will be resolved to the
+// BaseURL of the Client. Relative URLS should always be specified without a preceding slash.
+func (c *Client) NewPlainRequest(ctx context.Context, method, urlStr string) (*http.Request, error) {
+	req, err := c.newRequest(urlStr, method)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Accept", plainMediaType)
+
+	return req, nil
+}
+
+func (c *Client) newRequest(urlStr, method string) (*http.Request, error) {
 	if !strings.HasSuffix(c.BaseURL.Path, "/") {
 		return nil, fmt.Errorf("base URL must have a trailing slash, but %q does not", c.BaseURL)
 	}
@@ -346,8 +421,6 @@ func (c *Client) NewGZipRequest(ctx context.Context, method, urlStr string) (*ht
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header.Add("Accept", gzipMediaType)
 	if c.UserAgent != "" {
 		req.Header.Set("User-Agent", c.UserAgent)
 	}
@@ -380,9 +453,18 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 	}
 
 	defer func() {
-		if rerr := resp.Body.Close(); err == nil {
-			err = rerr
+		// Ensure the response body is fully read and closed
+		// before we reconnect, so that we reuse the same TCP connection.
+		// Close the previous response's body. But read at least some of
+		// the body so if it's small the underlying TCP connection will be
+		// re-used. No need to check for errors: if it fails, the Transport
+		// won't reuse it anyway.
+		const maxBodySlurpSize = 2 << 10
+		if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+			_, _ = io.CopyN(ioutil.Discard, resp.Body, maxBodySlurpSize)
 		}
+
+		resp.Body.Close()
 	}()
 
 	response := &Response{Response: resp}
@@ -414,7 +496,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*Res
 
 func (r *ErrorResponse) Error() string {
 	return fmt.Sprintf("%v %v: %d (request %q) %v",
-		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.Reason, r.Detail)
+		r.Response.Request.Method, r.Response.Request.URL, r.Response.StatusCode, r.ErrorCode, r.Detail)
 }
 
 // CheckResponse checks the API response for errors, and returns them if present. A response is considered an

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/organizations.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/organizations.go
@@ -28,7 +28,7 @@ const (
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/organizations/
 type OrganizationsService interface {
-	List(context.Context, *ListOptions) (*Organizations, *Response, error)
+	List(context.Context, *OrganizationsListOptions) (*Organizations, *Response, error)
 	Get(context.Context, string) (*Organization, *Response, error)
 	Projects(context.Context, string, *ListOptions) (*Projects, *Response, error)
 	Users(context.Context, string, *ListOptions) (*AtlasUsersResponse, *Response, error)
@@ -39,6 +39,13 @@ type OrganizationsService interface {
 type OrganizationsServiceOp service
 
 var _ OrganizationsService = &OrganizationsServiceOp{}
+
+// OrganizationsListOptions filtering options for organizations
+type OrganizationsListOptions struct {
+	Name               string `url:"name,omitempty"`
+	IncludeDeletedOrgs *bool  `url:"includeDeletedOrgs,omitempty"`
+	ListOptions
+}
 
 // Organization represents the structure of an organization.
 type Organization struct {
@@ -58,7 +65,7 @@ type Organizations struct {
 // List gets all organizations.
 //
 // See more: https://docs.atlas.mongodb.com/reference/api/organization-get-all/
-func (s *OrganizationsServiceOp) List(ctx context.Context, opts *ListOptions) (*Organizations, *Response, error) {
+func (s *OrganizationsServiceOp) List(ctx context.Context, opts *OrganizationsListOptions) (*Organizations, *Response, error) {
 	path, err := setListOptions(orgsBasePath, opts)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/peers.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/peers.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/performance_advisor.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/performance_advisor.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/private_endpoints_deprecated.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/private_endpoints_deprecated.go
@@ -1,0 +1,246 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mongodbatlas
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// PrivateEndpointsServiceDeprecated is an interface for interfacing with the Private Endpoints
+// of the MongoDB Atlas API.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint/
+type PrivateEndpointsServiceDeprecated interface {
+	Create(context.Context, string, *PrivateEndpointConnectionDeprecated) (*PrivateEndpointConnectionDeprecated, *Response, error)
+	Get(context.Context, string, string) (*PrivateEndpointConnectionDeprecated, *Response, error)
+	List(context.Context, string, *ListOptions) ([]PrivateEndpointConnectionDeprecated, *Response, error)
+	Delete(context.Context, string, string) (*Response, error)
+	AddOneInterfaceEndpoint(context.Context, string, string, string) (*InterfaceEndpointConnectionDeprecated, *Response, error)
+	GetOneInterfaceEndpoint(context.Context, string, string, string) (*InterfaceEndpointConnectionDeprecated, *Response, error)
+	DeleteOneInterfaceEndpoint(context.Context, string, string, string) (*Response, error)
+}
+
+// PrivateEndpointsServiceOpDeprecated handles communication with the PrivateEndpoints related methods
+// of the MongoDB Atlas API
+type PrivateEndpointsServiceOpDeprecated service
+
+var _ PrivateEndpointsServiceDeprecated = &PrivateEndpointsServiceOpDeprecated{}
+
+// PrivateEndpointConnectionDeprecated represents MongoDB Private Endpoint Connection.
+type PrivateEndpointConnectionDeprecated struct {
+	ID                  string   `json:"id,omitempty"`                  // Unique identifier of the AWS PrivateLink connection.
+	ProviderName        string   `json:"providerName,omitempty"`        // Name of the cloud provider you want to create the private endpoint connection for. Must be AWS.
+	Region              string   `json:"region,omitempty"`              // Cloud provider region in which you want to create the private endpoint connection.
+	EndpointServiceName string   `json:"endpointServiceName,omitempty"` // Name of the PrivateLink endpoint service in AWS. Returns null while the endpoint service is being created.
+	ErrorMessage        string   `json:"errorMessage,omitempty"`        // Error message pertaining to the AWS PrivateLink connection. Returns null if there are no errors.
+	InterfaceEndpoints  []string `json:"interfaceEndpoints,omitempty"`  // Unique identifiers of the interface endpoints in your VPC that you added to the AWS PrivateLink connection.
+	Status              string   `json:"status,omitempty"`              // Status of the AWS PrivateLink connection: INITIATING, WAITING_FOR_USER, FAILED, DELETING.
+}
+
+// InterfaceEndpointConnectionDeprecated represents MongoDB Interface Endpoint Connection.
+type InterfaceEndpointConnectionDeprecated struct {
+	ID               string `json:"interfaceEndpointId,omitempty"` // Unique identifier of the interface endpoint.
+	DeleteRequested  *bool  `json:"deleteRequested,omitempty"`     // Indicates if Atlas received a request to remove the interface endpoint from the private endpoint connection.
+	ErrorMessage     string `json:"errorMessage,omitempty"`        // Error message pertaining to the interface endpoint. Returns null if there are no errors.
+	ConnectionStatus string `json:"connectionStatus,omitempty"`    // Status of the interface endpoint: NONE, PENDING_ACCEPTANCE, PENDING, AVAILABLE, REJECTED, DELETING.
+}
+
+// Create one private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-create-one-private-endpoint-connection/
+func (s *PrivateEndpointsServiceOpDeprecated) Create(ctx context.Context, groupID string, createRequest *PrivateEndpointConnectionDeprecated) (*PrivateEndpointConnectionDeprecated, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if createRequest == nil {
+		return nil, nil, NewArgError("createRequest", "cannot be nil")
+	}
+
+	path := fmt.Sprintf(privateEndpointsPath, groupID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, createRequest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(PrivateEndpointConnectionDeprecated)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// Get retrieves details for one private endpoint connection by ID in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-get-one-private-endpoint-connection/
+func (s *PrivateEndpointsServiceOpDeprecated) Get(ctx context.Context, groupID, privateLinkID string) (*PrivateEndpointConnectionDeprecated, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, nil, NewArgError("privateLinkID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, privateLinkID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(PrivateEndpointConnectionDeprecated)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// List retrieves details for all private endpoint connections in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-get-all-private-endpoint-connections/
+func (s *PrivateEndpointsServiceOpDeprecated) List(ctx context.Context, groupID string, listOptions *ListOptions) ([]PrivateEndpointConnectionDeprecated, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+
+	path := fmt.Sprintf(privateEndpointsPath, groupID)
+
+	// Add query params from listOptions
+	path, err := setListOptions(path, listOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new([]PrivateEndpointConnectionDeprecated)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *root, resp, nil
+}
+
+// Delete removes one private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-delete-one-private-endpoint-connection/
+func (s *PrivateEndpointsServiceOpDeprecated) Delete(ctx context.Context, groupID, privateLinkID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, NewArgError("privateLinkID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s", basePath, privateLinkID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Client.Do(ctx, req, nil)
+}
+
+// AddOneInterfaceEndpoint adds one interface endpoint to a private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-create-one-interface-endpoint/
+func (s *PrivateEndpointsServiceOpDeprecated) AddOneInterfaceEndpoint(ctx context.Context, groupID, privateLinkID, interfaceEndpointID string) (*InterfaceEndpointConnectionDeprecated, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, nil, NewArgError("privateLinkID", "must be set")
+	}
+	if interfaceEndpointID == "" {
+		return nil, nil, NewArgError("interfaceEndpointID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s/interfaceEndpoints", basePath, privateLinkID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodPost, path, &InterfaceEndpointConnectionDeprecated{ID: interfaceEndpointID})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(InterfaceEndpointConnectionDeprecated)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// GetOneInterfaceEndpoint retrieves one interface endpoint in a private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-get-one-interface-endpoint/
+func (s *PrivateEndpointsServiceOpDeprecated) GetOneInterfaceEndpoint(ctx context.Context, groupID, privateLinkID, interfaceEndpointID string) (*InterfaceEndpointConnectionDeprecated, *Response, error) {
+	if groupID == "" {
+		return nil, nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, nil, NewArgError("privateLinkID", "must be set")
+	}
+	if interfaceEndpointID == "" {
+		return nil, nil, NewArgError("interfaceEndpointID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s/interfaceEndpoints/%s", basePath, privateLinkID, interfaceEndpointID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(InterfaceEndpointConnectionDeprecated)
+	resp, err := s.Client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, err
+}
+
+// DeleteOneInterfaceEndpoint removes one interface endpoint from a private endpoint connection in an Atlas project.
+// See more: https://docs.atlas.mongodb.com/reference/api/private-endpoint-delete-one-interface-endpoint/
+func (s *PrivateEndpointsServiceOpDeprecated) DeleteOneInterfaceEndpoint(ctx context.Context, groupID, privateLinkID, interfaceEndpointID string) (*Response, error) {
+	if groupID == "" {
+		return nil, NewArgError("groupID", "must be set")
+	}
+	if privateLinkID == "" {
+		return nil, NewArgError("privateLinkID", "must be set")
+	}
+	if interfaceEndpointID == "" {
+		return nil, NewArgError("interfaceEndpointID", "must be set")
+	}
+
+	basePath := fmt.Sprintf(privateEndpointsPath, groupID)
+	path := fmt.Sprintf("%s/%s/interfaceEndpoints/%s", basePath, privateLinkID, interfaceEndpointID)
+
+	req, err := s.Client.NewRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Client.Do(ctx, req, nil)
+}

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/private_ip_mode.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/private_ip_mode.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/process_database_measurements.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/process_database_measurements.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/process_databases.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/process_databases.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/process_disk_measurements.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/process_disk_measurements.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/process_disks.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/process_disks.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/process_measurements.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/process_measurements.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/processes.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/processes.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -34,6 +48,7 @@ type Process struct {
 	ReplicaSetName string  `json:"replicaSetName"`
 	TypeName       string  `json:"typeName"`
 	Version        string  `json:"version"`
+	UserAlias      string  `json:"userAlias"`
 }
 
 // processesResponse is the response from Processes.List.

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/project_api_key.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/project_api_key.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/project_ip_access_list.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/project_ip_access_list.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/project_ip_whitelist.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/project_ip_whitelist.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -11,7 +25,13 @@ const projectIPWhitelistPath = "groups/%s/whitelist"
 
 // ProjectIPWhitelistService is an interface for interfacing with the Project IP Whitelist
 // endpoints of the MongoDB Atlas API.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/whitelist/
+//
+// Deprecated: ProjectIPAccessListService replaces ProjectIPWhitelistService.
+// Atlas now refers to its cluster firewall management as IP Access Lists.
+// Atlas has deprecated the whitelist resource and will disable it in June 2021.
+// Please update any dependent work to use ProjectIPWhitelistService
 type ProjectIPWhitelistService interface {
 	List(context.Context, string, *ListOptions) ([]ProjectIPWhitelist, *Response, error)
 	Get(context.Context, string, string) (*ProjectIPWhitelist, *Response, error)

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/projects.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/projects.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/search.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/search.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/teams.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/teams.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/whitelist_api_keys.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/whitelist_api_keys.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (
@@ -10,7 +24,13 @@ const whitelistAPIKeysPath = "orgs/%s/apiKeys/%s/whitelist"
 
 // WhitelistAPIKeysService is an interface for interfacing with the Whitelist API Keys
 // endpoints of the MongoDB Atlas API.
+//
 // See more: https://docs.atlas.mongodb.com/reference/api/apiKeys/#organization-api-key-endpoints
+//
+// Deprecated: AccessListAPIKeysService replaces WhitelistAPIKeysService.
+// Atlas now refers to programmatic API key whitelists as access lists.
+// Atlas has deprecated the whitelist method and will disable it in June 2021.
+// Please update any dependent work to use WhitelistAPIKeysService
 type WhitelistAPIKeysService interface {
 	List(context.Context, string, string, *ListOptions) (*WhitelistAPIKeys, *Response, error)
 	Get(context.Context, string, string, string) (*WhitelistAPIKey, *Response, error)

--- a/vendor/go.mongodb.org/atlas/mongodbatlas/x509_authentication_database_users.go
+++ b/vendor/go.mongodb.org/atlas/mongodbatlas/x509_authentication_database_users.go
@@ -1,3 +1,17 @@
+// Copyright 2021 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mongodbatlas
 
 import (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -103,7 +103,7 @@ github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/ryanuber/go-glob v1.0.0
 github.com/ryanuber/go-glob
-# go.mongodb.org/atlas v0.5.0
+# go.mongodb.org/atlas v0.7.2
 go.mongodb.org/atlas/mongodbatlas
 # golang.org/x/crypto v0.0.0-20190418165655-df01cb2cc480
 golang.org/x/crypto/blake2b


### PR DESCRIPTION
This is related to [this git issue](https://github.com/hashicorp/vault-plugin-secrets-mongodbatlas/issues/11) . The suggested fix is to upgrade the dependency in the module to the latest version. 

The PR was generated by running `go get -u go.mongodb.org/atlas` and then `go mod vendor` . 