### PR TITLE
Replace usage of useragent.String with useragent.PluginString

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,8 @@ import (
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
+const userAgentPluginName = "secrets-mongodbatlas"
+
 func (b *Backend) clientMongo(ctx context.Context, s logical.Storage) (*mongodbatlas.Client, error) {
 	b.clientMutex.Lock()
 	defer b.clientMutex.Unlock()
@@ -27,13 +29,10 @@ func (b *Backend) clientMongo(ctx context.Context, s logical.Storage) (*mongodba
 
 	pluginEnv, err := b.system.PluginEnv(ctx)
 	if err != nil {
-		return nil, err
+		b.Logger().Warn("failed to read plugin environment, user-agent will not be set",
+			"error", err)
 	}
-	if pluginEnv != nil {
-		client.UserAgent = useragent.PluginString(pluginEnv, "mongodbatlas-secrets")
-	} else {
-		client.UserAgent = useragent.String()
-	}
+	client.UserAgent = useragent.PluginString(pluginEnv, userAgentPluginName)
 
 	b.client = client
 

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@ import (
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
-const userAgentPluginName = "secrets-mongodbatlas"
+const userAgentPluginName = "mongodbatlas-secrets"
 
 func (b *Backend) clientMongo(ctx context.Context, s logical.Storage) (*mongodbatlas.Client, error) {
 	b.clientMutex.Lock()

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package mongodbatlas
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
@@ -29,8 +30,7 @@ func (b *Backend) clientMongo(ctx context.Context, s logical.Storage) (*mongodba
 
 	pluginEnv, err := b.system.PluginEnv(ctx)
 	if err != nil {
-		b.Logger().Warn("failed to read plugin environment, user-agent will not be set",
-			"error", err)
+		return nil, fmt.Errorf("failed to read plugin environment: %w", err)
 	}
 	client.UserAgent = useragent.PluginString(pluginEnv, userAgentPluginName)
 


### PR DESCRIPTION
## Overview

This PR replaces usage of [`useragent.String`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L43) with [`useragent.PluginString`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L58). `useragent.String` has been deprecated. Using `useragent.PluginString` will allow plugins running external to Vault to use correct Vault version information in construction of user-agent request headers regardless of the compiled SDK version.

## Related Issues/Pull Requests
- https://github.com/hashicorp/vault/pull/14229
