### PR TITLE
Allow WAL rollback to handle partial failure when creating API keys

### DIFF
--- a/secret_programmatic_api_keys.go
+++ b/secret_programmatic_api_keys.go
@@ -65,11 +65,7 @@ func (b *Backend) programmaticAPIKeyCreate(ctx context.Context, s logical.Storag
 	}
 
 	if err != nil {
-		if walErr := framework.DeleteWAL(ctx, s, walID); walErr != nil {
-			dbUserErr := errwrap.Wrapf("error creating programmaticAPIKey: {{err}}", err)
-			return nil, errwrap.Wrap(errwrap.Wrapf("failed to delete WAL entry: {{err}}", walErr), dbUserErr)
-		}
-		return logical.ErrorResponse("Error creating programmatic api key: %s", err), err
+		return logical.ErrorResponse("Error creating programmatic api key: %s", err), nil
 	}
 
 	if key == nil {
@@ -244,7 +240,7 @@ func (b *Backend) programmaticAPIKeyRevoke(ctx context.Context, req *logical.Req
 	return nil, nil
 }
 
-func (b *Backend) pathProgrammaticAPIKeyRollback(ctx context.Context, req *logical.Request, _kind string, data interface{}) error {
+func (b *Backend) pathProgrammaticAPIKeyRollback(ctx context.Context, req *logical.Request, _ string, data interface{}) error {
 	var entry walEntry
 	if err := mapstructure.Decode(data, &entry); err != nil {
 		return err


### PR DESCRIPTION
## Overview

The WAL entry that allows the plugin to eventually clean up from partial failure was being immediately deleted. Instead, we should allow the [WAL rollback function](https://github.com/hashicorp/vault-plugin-secrets-mongodbatlas/blob/main/secret_programmatic_api_keys.go#L244) to eventually clean up from the partial failure.

Fixes https://github.com/hashicorp/vault-plugin-secrets-mongodbatlas/issues/27.

## Related Issues/Pull Requests

- https://github.com/hashicorp/vault-plugin-secrets-mongodbatlas/issues/27

## Contributor Checklist

- [ ] No documentation required
- [x] Backwards compatible
